### PR TITLE
Fix Fallen Knights being tamed without an owner.

### DIFF
--- a/src/main/java/crazypants/enderzoo/entity/EntityFallenMount.java
+++ b/src/main/java/crazypants/enderzoo/entity/EntityFallenMount.java
@@ -36,7 +36,7 @@ public class EntityFallenMount extends EntityHorse implements IEnderZooMob {
 
   public EntityFallenMount(World world) {
     super(world);
-    setHorseTamed(true);
+    //setHorseTamed(true);
     setGrowingAge(0);
     setHorseSaddled(true);
 
@@ -48,7 +48,7 @@ public class EntityFallenMount extends EntityHorse implements IEnderZooMob {
 
     findTargetAI = new EntityAINearestAttackableTarget(this, EntityPlayer.class, 0, true);
     attackAI = new EntityAIAttackOnCollide(this, EntityPlayer.class, MOUNTED_ATTACK_MOVE_SPEED, false);
-    updateAttackAI();    
+    updateAttackAI(); 
   }
 
   @Override


### PR DESCRIPTION
Currently, setHorseTamed is causing the horse to have no owner. This isn't an issue normally, but Cauldron protection plugins render horses unkillable.
This fixes that, and I don't _think_ has any other major impacts.
