### PR TITLE
Make Dire Slimes nastier

### DIFF
--- a/src/main/java/crazypants/enderzoo/entity/EntityDireSlime.java
+++ b/src/main/java/crazypants/enderzoo/entity/EntityDireSlime.java
@@ -167,4 +167,11 @@ public class EntityDireSlime extends EntityMagmaCube implements IEnderZooMob {
     }
   }
 
+  @Override
+  protected float applyArmorCalculations(DamageSource p_70655_1_, float p_70655_2_) {
+    if (!p_70655_1_.isUnblockable()) {
+      return Math.min(Math.max(p_70655_2_ - 3 - this.getSlimeSize(), this.getSlimeSize()) / 2, p_70655_2_);
+    }
+    return p_70655_2_;
+  }
 }


### PR DESCRIPTION
They now will ignore a part of the incoming damage.

Damage is reduced by 3+slimeSize hearts (4, 5, 7), but not below slimeSize/2 hearts (0.5, 1, 2).

In effect, a small slime needs 4 hits by hand or with a wooden sword (5 dmg), or 2 hits with a better vanilla sword (6/7/8 dmg). Medium slimes need 8 hits with the smaller swords, 5 hits with a diamond sword, or 3 critical hits with a diamond sword.

As their attacks are not too hard to avoid, they still can be killed by an unarmed player. However, even with a good weapon it takes a couple of hits to kill them, making it worthwhile to use a shovel to avoid creating them in the first place.