### PR TITLE
Closes #186

### DIFF
--- a/resources/assets/enderzoo/config/SpawnConfig_Core.xml
+++ b/resources/assets/enderzoo/config/SpawnConfig_Core.xml
@@ -61,7 +61,7 @@ Each filter must contain one or more biome entries
          The special name BASE_LAND_TYPES includes:
          MESA, FOREST, PLAINS, MOUNTAIN, HILLS, SWAMP, SANDY, SNOWY, WASTELAND, BEACH
          
-- name: The name of the biome. Must be exactly as registered.
+- name: The registry name of the biome. Must be exactly as registered, must be in the format modid:biome.  For vanilla, use minecraft as the modid.
          
 - exclude: (Optional, default false) when set to false any biomes matching this type will be excluded. For example, if
             FOREST is specified as a biome type, and CONIFEROUS is specified with the exclude set to true, then the mob will not

--- a/src/main/java/crazypants/enderzoo/config/SpawnConfigParser.java
+++ b/src/main/java/crazypants/enderzoo/config/SpawnConfigParser.java
@@ -172,15 +172,15 @@ public class SpawnConfigParser extends DefaultHandler {
   private void parseDimExclude(Attributes attributes) {
     String name = getStringValue(ATT_NAME, attributes, null);
     if (name != null) {
-      currentEntry.addDimensioFilter(new DimensionFilter(name));
+      currentEntry.addDimensionFilter(new DimensionFilter(name));
       return;
     }
     int id = getIntValue(ATT_ID, attributes, Integer.MAX_VALUE);
     if (id != Integer.MAX_VALUE) {
-      currentEntry.addDimensioFilter(new DimensionFilter(id));
+      currentEntry.addDimensionFilter(new DimensionFilter(id));
       return;
     }
-    currentEntry.addDimensioFilter(new DimensionFilter(getIntValue(ATT_ID_START, attributes, Integer.MAX_VALUE), getIntValue(ATT_ID_END, attributes,
+    currentEntry.addDimensionFilter(new DimensionFilter(getIntValue(ATT_ID_START, attributes, Integer.MAX_VALUE), getIntValue(ATT_ID_END, attributes,
         Integer.MAX_VALUE)));
 
   }

--- a/src/main/java/crazypants/enderzoo/config/SpawnConfigParser.java
+++ b/src/main/java/crazypants/enderzoo/config/SpawnConfigParser.java
@@ -26,6 +26,7 @@ import crazypants.enderzoo.spawn.impl.BiomeFilterAny;
 import crazypants.enderzoo.spawn.impl.DimensionFilter;
 import crazypants.enderzoo.spawn.impl.SpawnEntry;
 import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.BiomeDictionary.Type;
@@ -309,7 +310,7 @@ public class SpawnConfigParser extends DefaultHandler {
       }
       return;
     }
-    currentFilter.addBiomeDescriptor(new BiomeDescriptor(biomeName.trim(), isExclude));
+    currentFilter.addBiomeDescriptor(new BiomeDescriptor(new ResourceLocation(biomeName.trim()), isExclude));
   }
 
   protected boolean isEmptyString(String str) {

--- a/src/main/java/crazypants/enderzoo/spawn/IBiomeDescriptor.java
+++ b/src/main/java/crazypants/enderzoo/spawn/IBiomeDescriptor.java
@@ -7,7 +7,7 @@ public interface IBiomeDescriptor {
 
   BiomeDictionary.Type getType();
 
-  ResourceLocation getName();
+  ResourceLocation getRegistryName();
 
   boolean isExclude();
 

--- a/src/main/java/crazypants/enderzoo/spawn/IBiomeDescriptor.java
+++ b/src/main/java/crazypants/enderzoo/spawn/IBiomeDescriptor.java
@@ -1,12 +1,13 @@
 package crazypants.enderzoo.spawn;
 
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.BiomeDictionary;
 
 public interface IBiomeDescriptor {
 
   BiomeDictionary.Type getType();
 
-  String getName();
+  ResourceLocation getName();
 
   boolean isExclude();
 

--- a/src/main/java/crazypants/enderzoo/spawn/impl/AbstractBiomeFilter.java
+++ b/src/main/java/crazypants/enderzoo/spawn/impl/AbstractBiomeFilter.java
@@ -26,11 +26,11 @@ public abstract class AbstractBiomeFilter implements IBiomeFilter {
       } else {
         types.add(biome.getType());
       }
-    } else if (biome.getName() != null) {
+    } else if (biome.getRegistryName() != null) {
       if (biome.isExclude()) {
-        nameExcludes.add(biome.getName());
+        nameExcludes.add(biome.getRegistryName());
       } else {
-        names.add(biome.getName());
+        names.add(biome.getRegistryName());
       }
     }
   }

--- a/src/main/java/crazypants/enderzoo/spawn/impl/AbstractBiomeFilter.java
+++ b/src/main/java/crazypants/enderzoo/spawn/impl/AbstractBiomeFilter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import crazypants.enderzoo.config.Config;
 import crazypants.enderzoo.spawn.IBiomeDescriptor;
 import crazypants.enderzoo.spawn.IBiomeFilter;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.BiomeDictionary;
 
@@ -14,8 +15,8 @@ public abstract class AbstractBiomeFilter implements IBiomeFilter {
   protected final List<BiomeDictionary.Type> types = new ArrayList<BiomeDictionary.Type>();
   protected final List<BiomeDictionary.Type> typeExcludes = new ArrayList<BiomeDictionary.Type>();
 
-  protected final List<String> names = new ArrayList<String>();
-  protected final List<String> nameExcludes = new ArrayList<String>();
+  protected final List<ResourceLocation> names = new ArrayList<ResourceLocation>();
+  protected final List<ResourceLocation> nameExcludes = new ArrayList<ResourceLocation>();
 
   @Override
   public void addBiomeDescriptor(IBiomeDescriptor biome) {
@@ -44,9 +45,9 @@ public abstract class AbstractBiomeFilter implements IBiomeFilter {
 
       }
     }
-    for (String exName : nameExcludes) {
-      if (exName != null && exName.equals(candidate.getBiomeName())) {
-        System.out.print("Excluded " + candidate.getBiomeName() + ", ");
+    for (ResourceLocation exName : nameExcludes) {
+      if (exName != null && exName.equals(candidate.getRegistryName())) {
+        System.out.print("Excluded " + candidate.getRegistryName() + ", ");
         return false;
       }
     }

--- a/src/main/java/crazypants/enderzoo/spawn/impl/BiomeDescriptor.java
+++ b/src/main/java/crazypants/enderzoo/spawn/impl/BiomeDescriptor.java
@@ -24,7 +24,7 @@ public class BiomeDescriptor implements IBiomeDescriptor {
   }
 
   @Override
-  public ResourceLocation getName() {
+  public ResourceLocation getRegistryName() {
     return name;
   }
 

--- a/src/main/java/crazypants/enderzoo/spawn/impl/BiomeDescriptor.java
+++ b/src/main/java/crazypants/enderzoo/spawn/impl/BiomeDescriptor.java
@@ -1,12 +1,13 @@
 package crazypants.enderzoo.spawn.impl;
 
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.BiomeDictionary.Type;
 import crazypants.enderzoo.spawn.IBiomeDescriptor;
 
 public class BiomeDescriptor implements IBiomeDescriptor {
 
-  private final String name;
+  private final ResourceLocation name;
   private final BiomeDictionary.Type type;
   private final boolean isExclude;
 
@@ -16,14 +17,14 @@ public class BiomeDescriptor implements IBiomeDescriptor {
     this.isExclude = isExclude;
   }
 
-  public BiomeDescriptor(String name, boolean isExclude) {
+  public BiomeDescriptor(ResourceLocation name, boolean isExclude) {
     this.name = name;
     type = null;
     this.isExclude = isExclude;
   }
 
   @Override
-  public String getName() {
+  public ResourceLocation getName() {
     return name;
   }
 

--- a/src/main/java/crazypants/enderzoo/spawn/impl/BiomeFilterAll.java
+++ b/src/main/java/crazypants/enderzoo/spawn/impl/BiomeFilterAll.java
@@ -33,7 +33,7 @@ public class BiomeFilterAll extends AbstractBiomeFilter {
     if (isExcluded(biome)) {
       return false;
     }
-    if (!names.isEmpty() && !names.contains(biome.getBiomeName())) {
+    if (!names.isEmpty() && !names.contains(biome.getRegistryName())) {
       return false;
     }
     for (BiomeDictionary.Type type : types) {

--- a/src/main/java/crazypants/enderzoo/spawn/impl/BiomeFilterAny.java
+++ b/src/main/java/crazypants/enderzoo/spawn/impl/BiomeFilterAny.java
@@ -32,7 +32,7 @@ public class BiomeFilterAny extends AbstractBiomeFilter {
     if (isExcluded(biome)) {
       return false;
     }
-    if (names.contains(biome.getBiomeName())) {
+    if (names.contains(biome.getRegistryName())) {
       return true;
     }
     for (BiomeDictionary.Type type : types) {

--- a/src/main/java/crazypants/enderzoo/spawn/impl/SpawnEntry.java
+++ b/src/main/java/crazypants/enderzoo/spawn/impl/SpawnEntry.java
@@ -38,7 +38,7 @@ public class SpawnEntry implements ISpawnEntry {
     return filters;
   }
 
-  public void addDimensioFilter(DimensionFilter filter) {
+  public void addDimensionFilter(DimensionFilter filter) {
     dimFilters.add(filter);
   }
 


### PR DESCRIPTION
Switches the XML config system to use biome registry name instead of biome name, as the method to access the biome name (Biome#getName) was changed to SideOnly(Side.CLIENT) in 1.12.